### PR TITLE
MAKE-330 Add support for version range tests

### DIFF
--- a/check/python_module.go
+++ b/check/python_module.go
@@ -27,6 +27,8 @@ type pythonModuleVersion struct {
 	Module            string `bson:"module" json:"module" yaml:"module"`
 	Statement         string `bson:"statement" json:"statement" yaml:"statement"`
 	Version           string `bson:"version" json:"version" yaml:"version"`
+	MinVersion        string `bson:"minVersion" json:"minVersion" yaml:"minVersion"`
+	MinRelationship   string `bson:"minRelationship" json:"minRelationship" yaml:"minRelationship"`
 	PythonInterpreter string `bson:"python" json:"python" yaml:"python"`
 	Relationship      string `bson:"relationship" json:"relationship" yaml:"relationship"`
 	*Base             `bson:"metadata" json:"metadata" yaml:"metadata"`
@@ -51,6 +53,17 @@ func (c *pythonModuleVersion) validate() error {
 			c.Relationship, c.ID())
 	}
 
+	switch c.MinRelationship {
+	case "":
+		grip.Debug("no relationship specified, using greater than or equal to (gte)")
+		c.MinRelationship = "gte"
+	case "gte", "lte", "lt", "gt", "eq":
+		grip.Debugln("relationship for '%s' check set to '%s'", c.ID(), c.MinRelationship)
+	default:
+		return errors.Errorf("relationship '%s' for check '%s' is invalid",
+			c.MinRelationship, c.ID())
+	}
+
 	return nil
 }
 
@@ -71,6 +84,17 @@ func (c *pythonModuleVersion) Run() {
 		c.AddError(err)
 		c.setMessage(fmt.Sprintf("could not parse expected version '%s'", c.Version))
 		return
+	}
+
+	var minExpected semver.Version
+	if c.MinVersion != "" {
+		minExpected, err = semver.Parse(c.MinVersion)
+		if err != nil {
+			c.setState(false)
+			c.AddError(err)
+			c.setMessage(fmt.Sprintf("could not parse expected version '%s'", c.Version))
+			return
+		}
 	}
 
 	cmdArgs := []string{
@@ -97,13 +121,25 @@ func (c *pythonModuleVersion) Run() {
 		return
 	}
 
-	result, err := compareVersions(c.Relationship, parsed, expected)
+	var result bool
+	result, err = compareVersions(c.Relationship, parsed, expected)
 	if err != nil {
 		// this should be unreachable, because the earlier
 		// validate will have caught it.
 		c.setState(false)
 		c.AddError(err)
 		return
+	}
+
+	if c.MinVersion != "" {
+		gteMin, err := compareVersions(c.MinRelationship, parsed, minExpected)
+		if err != nil {
+			c.setState(false)
+			c.AddError(err)
+			return
+		}
+
+		result = result && gteMin
 	}
 
 	if !result {

--- a/check/python_module.go
+++ b/check/python_module.go
@@ -44,24 +44,23 @@ func (c *pythonModuleVersion) validate() error {
 
 	switch c.Relationship {
 	case "":
-		grip.Debug("no relationship specified, using greater than or equal to (gte)")
-		c.Relationship = "gte"
+		if c.MinVersion != "" {
+			c.Relationship = "lte"
+		} else {
+			c.Relationship = "gte"
+		}
+
+		grip.Debugf("no relationship specified, using %s", c.Relationship)
 	case "gte", "lte", "lt", "gt", "eq":
 		grip.Debugln("relationship for '%s' check set to '%s'", c.ID(), c.Relationship)
-	default:
-		return errors.Errorf("relationship '%s' for check '%s' is invalid",
-			c.Relationship, c.ID())
 	}
 
 	switch c.MinRelationship {
 	case "":
-		grip.Debug("no relationship specified, using greater than or equal to (gte)")
+		grip.Debug("no min relationship specified, using greater than or equal to (gte)")
 		c.MinRelationship = "gte"
 	case "gte", "lte", "lt", "gt", "eq":
 		grip.Debugln("relationship for '%s' check set to '%s'", c.ID(), c.MinRelationship)
-	default:
-		return errors.Errorf("relationship '%s' for check '%s' is invalid",
-			c.MinRelationship, c.ID())
 	}
 
 	return nil

--- a/check/python_module_test.go
+++ b/check/python_module_test.go
@@ -127,3 +127,29 @@ func (s *PythonModuleSuite) TestReturnsErrorWhenExpectedValueDoesNotPassComparis
 	s.Error(s.check.Error())
 	s.False(s.check.Output().Passed)
 }
+
+func (s *PythonModuleSuite) TestMinMaxVersionPasses() {
+	s.check.Version = "1.1.0"
+	s.check.MinVersion = "1.0.0"
+	s.check.Statement = "'1.0.9'"
+	s.check.Relationship = "lte"
+
+	s.NoError(s.check.validate())
+
+	s.check.Run()
+	s.True(s.check.Error() == nil)
+	s.True(s.check.Output().Passed)
+}
+
+func (s *PythonModuleSuite) TestMinMaxVersionReturnsErrorWhenExpectedValueDoesNotPassComparison() {
+	s.check.Version = "1.1.0"
+	s.check.MinVersion = "1.0.0"
+	s.check.Statement = "'1.1.9'"
+	s.check.Relationship = "lte"
+
+	s.NoError(s.check.validate())
+
+	s.check.Run()
+	s.Error(s.check.Error())
+	s.False(s.check.Output().Passed)
+}

--- a/check/python_module_test.go
+++ b/check/python_module_test.go
@@ -85,7 +85,6 @@ func (s *PythonModuleSuite) TestDefaultFixtureProducesPassingResult() {
 
 func (s *PythonModuleSuite) TestReturnsErrorWithInvalidComparator() {
 	s.check.Relationship = "neq"
-	s.Error(s.check.validate())
 
 	s.check.Run()
 	s.Error(s.check.Error())


### PR DESCRIPTION
  Patch Build: https://evergreen.mongodb.com/version/5a4d3772c9ec441966000923